### PR TITLE
Silence noise from `which` test commands output

### DIFF
--- a/hook
+++ b/hook
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-NODE=`which node`
-NODEJS=`which nodejs`
-IOJS=`which iojs`
+NODE=`which node 2> /dev/null`
+NODEJS=`which nodejs 2> /dev/null`
+IOJS=`which iojs 2> /dev/null`
 LOCAL="/usr/local/bin/node"
 
 if [[ -n $NODE ]]; then


### PR DESCRIPTION
The current hook causes a lot of unnecessary noise when the hook tries to assign the output of the `which` command to `NODE`, `NODEJS`, `IOJS`, and `LOCAL`:

```
which: no nodejs in (/usr/lib/git-core:/usr/local/sbin:/usr/local/bin:/home/akiva/.nvm/v0.11.16/bin:/home/akiva/.rbenv/bin:/home/akiva/bin:/usr/local/sbin:/usr/local/bin:/home/akiva/.rbenv/shims:/home/akiva/.rbenv/bin:/home/akiva/bin:/usr/local/sbin:/usr/local/bin[33/2763]
:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl)
which: no iojs in (/usr/lib/git-core:/usr/local/sbin:/usr/local/bin:/home/akiva/.nvm/v0.11.16/bin:/home/akiva/.rbenv/bin:/home/akiva/bin:/usr/local/sbin:/usr/local/bin:/home/akiva/.rbenv/shims:/home/akiva/.rbenv/bin:/home/akiva/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/
usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl)
```

This silences the results from directly spamming the terminal while still assigning to the `var`s in question.